### PR TITLE
[고도화] MySQL -> PostgreSQL 

### DIFF
--- a/exboard5/src/main/resources/application.yml
+++ b/exboard5/src/main/resources/application.yml
@@ -12,10 +12,13 @@ spring:
 #    url: jdbc:h2:tcp://localhost/~/test
 #    username: sa
 #    driver-class-name: org.h2.Driver
-    url: jdbc:mysql://localhost:3306/exboard5
-    username: ex5user
-    password: 1234
-    driver-class-name: com.mysql.cj.jdbc.Driver
+#    url: jdbc:mysql://localhost:3306/exboard5
+#    username: ex5user
+#    password: 1234
+#    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:postgresql://localhost:5432/board
+    username: postgres
+    password: asdf1234
   jpa:
     open-in-view: false
     defer-datasource-initialization: true

--- a/exboard5/src/main/resources/data.sql
+++ b/exboard5/src/main/resources/data.sql
@@ -7,7 +7,7 @@ values ('uno', '{noop}asdf1234', 'Uno', 'uno@mail.com', 'I am Uno.', now(), 'uno
 
 insert into user_account (user_id, user_password, nickname, email, memo, created_at, created_by, modified_at,
                           modified_by)
-values ('uno2', '{noop}asdf1234', 'kk', 'kk@mail.com', 'I am kk.', now(), 'kk', now(), 'kk')
+values ('kk', '{noop}asdf1234', 'kk', 'kk@mail.com', 'I am kk.', now(), 'kk', now(), 'kk')
 ;
 
 insert into user_account (user_id, user_password, nickname, email, memo, created_at, created_by, modified_at,


### PR DESCRIPTION
JPA의 이점을 활용하여, 간단하게 프로젝트 DB를 MySQL -> PostgreSQL로 전환 성공.

드라이버는 자동 선택되므로 지우는 것이 더 효율적
`(application.yaml -> spring.datasource.driver-class-name: )`