### PR TITLE
[고도화] 보안 기능 고도화 - 환경변수 사용

### DIFF
--- a/exboard5/src/main/resources/application.yml
+++ b/exboard5/src/main/resources/application.yml
@@ -16,9 +16,9 @@ spring:
 #    username: ex5user
 #    password: 1234
 #    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:postgresql://localhost:5432/board
-    username: postgres
-    password: asdf1234
+    url: ${LOCAL_DB_URL}
+    username: ${LOCAL_DB_USERNAME}
+    password: ${LOCAL_DB_PASSWORD}
   jpa:
     open-in-view: false
     defer-datasource-initialization: true


### PR DESCRIPTION
이 pr은 `application.yml` 에 노출되어 있던 각종 민감정보를 변수로 치환하여 보안을 신경쓰도록 함. 

이전 과거 기록(커밋 노드)을 조회하면 여전히 노출된 값을 볼 수있으므로, 근본적인 해결을 하려면 
이 저장소를 통째로 지우고 새로 올리는 수 밖에 없음. 

This closes #84 