### PR TITLE
[고도화] 민감 정보의 환경변수 치환 후 테스트 실패 현상 수정

### DIFF
--- a/exboard5/src/main/resources/application.yml
+++ b/exboard5/src/main/resources/application.yml
@@ -57,6 +57,9 @@ server:
 
 spring:
   config.activate.on-profile: testdb
+  datasource:
+    url: jdbc:h2:mem:board;mode=mysql
+#    url: jdbc:h2:mem:testdb
 #  datasource:
 #    url: jdbc:h2:mem:board;mode=mysql
 #    driver-class-name: org.h2.Driver

--- a/exboard5/src/test/java/Exboard5ApplicationTests.java
+++ b/exboard5/src/test/java/Exboard5ApplicationTests.java
@@ -1,6 +1,8 @@
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class Exboard5ApplicationTests {
 


### PR DESCRIPTION
DB 접근 정보가 환경변수 문법으로 치환되었는데 `@SpringBootTest`가 이를 그대로 읽으면서 올바른 jdbc url 포맷이 아니므로 실패를 유발함.

이에 적당히 인메모리 테스트 db인 h2 경로를
새로 만든 테스트 전용 `test` 프로파일에 지정해주고, 테스트 실행 시 이 프로파일을 바라보게 하여 문제 해결.