### PR TITLE
[고도화] Swagger UI 로 API 문서화하기

### DIFF
--- a/exboard5/build.gradle
+++ b/exboard5/build.gradle
@@ -23,7 +23,8 @@ repositories {
 
 dependencies {
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.12'
-    implementation 'org.springdoc:springdoc-openapi-data-rest:1.6.12'
+    implementation 'org.springdoc:springdoc-openapi-javadoc:1.6.12'
+//    implementation 'org.springdoc:springdoc-openapi-data-rest:1.6.12'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/exboard5/src/main/java/com/a/exboard5/controller/MainController.java
+++ b/exboard5/src/main/java/com/a/exboard5/controller/MainController.java
@@ -1,7 +1,20 @@
 package com.a.exboard5.controller;
 
+import com.a.exboard5.dto.response.ArticleCommentResponse;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.time.LocalDateTime;
+
+
+/**
+ * <p>
+ *   메인 컨트롤러
+ *
+ *  <p>
+ *      테스트 중.
+ */
 
 @Controller
 public class MainController {
@@ -9,5 +22,25 @@ public class MainController {
     @GetMapping("/")
     public String root(){
         return "forward:/articles";
+    }
+
+    /**
+     * 댓글 정보 열람.
+     *
+     * @param id 댓글 ID
+     * @return  댓글 응답
+     */
+
+    @ResponseBody
+    @GetMapping("/test-rest")
+    public ArticleCommentResponse test(Long id){
+        return ArticleCommentResponse.of(
+                id,
+                "content",
+                LocalDateTime.now(),
+                "test_email@mail.com",
+                "test_nickname",
+                "test_userId"
+        );
     }
 }

--- a/exboard5/src/main/java/com/a/exboard5/dto/response/ArticleCommentResponse.java
+++ b/exboard5/src/main/java/com/a/exboard5/dto/response/ArticleCommentResponse.java
@@ -7,6 +7,9 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.time.LocalDateTime;
 
+/**
+ *  댓글 응답 표준 포맷
+ */
 public record ArticleCommentResponse(
         Long id,
         String content,


### PR DESCRIPTION
간단한 의존성 추가만으로 즉시 스웨거 문서화가 진행됨.
이 때 Spring Data Rest 가 자동으로 만들어 준 api를 스웨거에 노출시키기 위해 추가 의존성을 사용함.